### PR TITLE
pnc_any

### DIFF
--- a/3_postnatal_care.do
+++ b/3_postnatal_care.do
@@ -22,7 +22,7 @@
 	*c_pnc_any : mother OR child receive PNC in first six weeks by skilled health worker
     gen c_pnc_any = 0 if !mi(m70) & !mi(m50) 
     replace c_pnc_any = 1 if (m71 <= 306 & m72_skill == 1 ) | (m51 <= 306 & m52_skill == 1)
-    replace c_pnc_any = . if inlist(m71,199,299,399,998)| inlist(m51,998)| m72_skill == . | m52_skill == .
+    replace c_pnc_any = . if ((inlist(m71,199,299,399,998)|m72_skill ==.) & m70 !=0) | ((inlist(m51,199,299,399,998) | m52_skill == .) & m50 !=0)
 
 	
 	*c_pnc_eff: mother AND child in first 24h by skilled health worker	


### PR DESCRIPTION
the original code will treat "mother receive no care, child receive care" and the versa as missing, and "both mother and child receive no care" as missing.
I suggest changing the code this way to treat the first case as 1, the second case as 0.