### PR TITLE
med & medfor

### DIFF
--- a/8_child_illness.do
+++ b/8_child_illness.do
@@ -68,15 +68,15 @@ order *,sequential  //make sure variables are in order.
         gen c_diarrhea_mof = (h38 == 5) if !inlist(h38,.,8) & c_diarrhea == 1
 
 *c_diarrhea_medfor Get formal medicine except (ors hmf home other_med, country specific). 
+	recode h12z h15 h15a h15b h15c h15d h15e h15f h15g h15h h15i (8 9 =.)
         egen medfor = rowtotal(h12z h15 h15a h15b h15c h15e h15g h15h h15i),mi
-		gen c_diarrhea_medfor = ( medfor > = 1 ) if c_diarrhea == 1
-		// formal medicine don't include "home remedy, herbal medicine and other"
-        replace c_diarrhea_medfor = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15e == 8  | h15g == 8 | h15h == 8 | h15i == 8 )                                       
-
+	gen c_diarrhea_medfor = ( medfor > = 1) if c_diarrhea == 1 & medfor!=.
+	// formal medicine don't include "home remedy, herbal medicine and other"
+        // replace c_diarrhea_medfor = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15e == 8  | h15g == 8 | h15h == 8 | h15i == 8 )                                       
 *c_diarrhea_med	Child with diarrhea received any medicine other than ORS or hmf (country specific)
         egen med = rowtotal(h12z h15 h15a h15b h15c h15d h15e h15f h15g h15h h15i),mi
-        gen c_diarrhea_med = ( med > = 1 ) if c_diarrhea == 1
-        replace c_diarrhea_med = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15d == 8 | h15e == 8 | h15f == 8 | h15g == 8 | h15h == 8 | h15i == 8 )
+        gen c_diarrhea_med = ( med > = 1 ) if c_diarrhea == 1 & med !=.
+        //replace c_diarrhea_med = . if (h12z == 8 | h15 == 8 | h15a == 8 | h15b == 8 | h15c == 8 | h15d == 8 | h15e == 8 | h15f == 8 | h15g == 8 | h15h == 8 | h15i == 8 )
 		
 *c_diarrheaact	Child with diarrhea seen by provider OR given any form of formal treatment
         gen c_diarrheaact = (c_diarrhea_pro==1 | c_diarrhea_medfor==1 | c_diarrhea_hmf==1 | c_treatdiarrhea==1) if c_diarrhea == 1


### PR DESCRIPTION
I suggest this code not only to deal with value "9"(no response) but also to treat missing conditions consistently. 
"egen medfor = rowtotal(h12z h15 h15a h15b h15c h15e h15g h15h h15i),mi" will code medfor=. only when all variables involved are missing.
But the original "replace...." will change medfor =. if any of the variables equal "8"
Considering that h15* having no value is quite common, I suggest we apply the "when all h15* missing, code missing" rule to h15* = 8,9, . 